### PR TITLE
fix: dont replace numbers

### DIFF
--- a/src/Localization/Translator.php
+++ b/src/Localization/Translator.php
@@ -88,7 +88,7 @@ class Translator implements ITranslator
 	{
 		if (isset($this->dictionary[$key])) {
 			$message = $this->dictionary[$key];
-		} elseif (preg_match('/^(\w+\.)+\w+$/', $key)) {
+		} elseif (preg_match('/^([A-Za-z]\w+\.)+\w+$/', $key)) {
 			$message = '|' . $key . '|';
 		} else {
 			$message = $key;


### PR DESCRIPTION
example 1.5M was replaced by untranslated string |1.5M|